### PR TITLE
Robomaker resources support

### DIFF
--- a/resources/robomaker-deployment-jobs.go
+++ b/resources/robomaker-deployment-jobs.go
@@ -1,0 +1,72 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+)
+
+type RoboMakerDeploymentJob struct {
+	svc  *robomaker.RoboMaker
+	name *string
+	arn  *string
+}
+
+func init() {
+	register("RoboMakerDeploymentJob", ListRoboMakerDeploymentJobs)
+}
+
+func deploymentJobNeedsToBeCanceled(job *robomaker.DeploymentJob) bool {
+	for _, n := range []string{"Completed", "Failed", "RunningFailed", "Terminating", "Terminated", "Canceled"} {
+		if job.Status != nil && *job.Status == n {
+			return false
+		}
+	}
+	return true
+}
+
+func ListRoboMakerDeploymentJobs(sess *session.Session) ([]Resource, error) {
+	svc := robomaker.New(sess)
+	resources := []Resource{}
+
+	params := &robomaker.ListDeploymentJobsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListDeploymentJobs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, deploymentJob := range resp.DeploymentJobs {
+			if deploymentJobNeedsToBeCanceled(deploymentJob) {
+				resources = append(resources, &RoboMakerDeploymentJob{
+					svc: svc,
+					arn: deploymentJob.Arn,
+				})
+			}
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RoboMakerDeploymentJob) Remove() error {
+
+	_, err := f.svc.CancelDeploymentJob(&robomaker.CancelDeploymentJobInput{
+		Job: f.arn,
+	})
+
+	return err
+}
+
+func (f *RoboMakerDeploymentJob) String() string {
+	return *f.arn
+}

--- a/resources/robomaker-fleets.go
+++ b/resources/robomaker-fleets.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+)
+
+type RoboMakerFleet struct {
+	svc  *robomaker.RoboMaker
+	name *string
+	arn  *string
+}
+
+func init() {
+	register("RoboMakerFleet", ListRoboMakerFleets)
+}
+
+func ListRoboMakerFleets(sess *session.Session) ([]Resource, error) {
+	svc := robomaker.New(sess)
+	resources := []Resource{}
+
+	params := &robomaker.ListFleetsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListFleets(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, fleet := range resp.FleetDetails {
+			resources = append(resources, &RoboMakerFleet{
+				svc:  svc,
+				name: fleet.Name,
+				arn:  fleet.Arn,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RoboMakerFleet) Remove() error {
+
+	_, err := f.svc.DeleteFleet(&robomaker.DeleteFleetInput{
+		Fleet: f.arn,
+	})
+
+	return err
+}
+
+func (f *RoboMakerFleet) String() string {
+	return *f.name
+}

--- a/resources/robomaker-robot-applications.go
+++ b/resources/robomaker-robot-applications.go
@@ -1,0 +1,69 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+)
+
+type RoboMakerRobotApplication struct {
+	svc     *robomaker.RoboMaker
+	name    *string
+	arn     *string
+	version *string
+}
+
+func init() {
+	register("RoboMakerRobotApplication", ListRoboMakerRobotApplications)
+}
+
+func ListRoboMakerRobotApplications(sess *session.Session) ([]Resource, error) {
+	svc := robomaker.New(sess)
+	resources := []Resource{}
+
+	params := &robomaker.ListRobotApplicationsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListRobotApplications(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, robotApplication := range resp.RobotApplicationSummaries {
+			resources = append(resources, &RoboMakerRobotApplication{
+				svc:     svc,
+				name:    robotApplication.Name,
+				arn:     robotApplication.Arn,
+				version: robotApplication.Version,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RoboMakerRobotApplication) Remove() error {
+
+	request := robomaker.DeleteRobotApplicationInput{
+		Application: f.arn,
+	}
+	if f.version != nil && *f.version != "$LATEST" {
+		request.ApplicationVersion = f.version
+	}
+
+	_, err := f.svc.DeleteRobotApplication(&request)
+
+	return err
+}
+
+func (f *RoboMakerRobotApplication) String() string {
+	return *f.name
+}

--- a/resources/robomaker-robots.go
+++ b/resources/robomaker-robots.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+)
+
+type RoboMakerRobot struct {
+	svc  *robomaker.RoboMaker
+	name *string
+	arn  *string
+}
+
+func init() {
+	register("RoboMakerRobot", ListRoboMakerRobots)
+}
+
+func ListRoboMakerRobots(sess *session.Session) ([]Resource, error) {
+	svc := robomaker.New(sess)
+	resources := []Resource{}
+
+	params := &robomaker.ListRobotsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListRobots(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, robot := range resp.Robots {
+			resources = append(resources, &RoboMakerRobot{
+				svc:  svc,
+				name: robot.Name,
+				arn:  robot.Arn,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RoboMakerRobot) Remove() error {
+
+	_, err := f.svc.DeleteRobot(&robomaker.DeleteRobotInput{
+		Robot: f.arn,
+	})
+
+	return err
+}
+
+func (f *RoboMakerRobot) String() string {
+	return *f.name
+}

--- a/resources/robomaker-simulation-applications.go
+++ b/resources/robomaker-simulation-applications.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+)
+
+type RoboMakerSimulationApplication struct {
+	svc     *robomaker.RoboMaker
+	name    *string
+	arn     *string
+	version *string
+}
+
+func init() {
+	register("RoboMakerSimulationApplication", ListRoboMakerSimulationApplications)
+}
+
+func ListRoboMakerSimulationApplications(sess *session.Session) ([]Resource, error) {
+	svc := robomaker.New(sess)
+	resources := []Resource{}
+
+	params := &robomaker.ListSimulationApplicationsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListSimulationApplications(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, robotSimulationApplication := range resp.SimulationApplicationSummaries {
+			resources = append(resources, &RoboMakerSimulationApplication{
+				svc:     svc,
+				name:    robotSimulationApplication.Name,
+				arn:     robotSimulationApplication.Arn,
+				version: robotSimulationApplication.Version,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RoboMakerSimulationApplication) Remove() error {
+
+	request := robomaker.DeleteSimulationApplicationInput{
+		Application: f.arn,
+	}
+	if f.version != nil && *f.version != "$LATEST" {
+		request.ApplicationVersion = f.version
+	}
+	_, err := f.svc.DeleteSimulationApplication(&request)
+
+	return err
+}
+
+func (f *RoboMakerSimulationApplication) String() string {
+	return *f.name
+}

--- a/resources/robomaker-simulation-jobs.go
+++ b/resources/robomaker-simulation-jobs.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/robomaker"
+)
+
+type RoboMakerSimulationJob struct {
+	svc  *robomaker.RoboMaker
+	name *string
+	arn  *string
+}
+
+func init() {
+	register("RoboMakerSimulationJob", ListRoboMakerSimulationJobs)
+}
+
+func simulationJobNeedsToBeCanceled(job *robomaker.SimulationJobSummary) bool {
+	for _, n := range []string{"Completed", "Failed", "RunningFailed", "Terminating", "Terminated", "Canceled"} {
+		if job.Status != nil && *job.Status == n {
+			return false
+		}
+	}
+	return true
+}
+func ListRoboMakerSimulationJobs(sess *session.Session) ([]Resource, error) {
+	svc := robomaker.New(sess)
+	resources := []Resource{}
+
+	params := &robomaker.ListSimulationJobsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListSimulationJobs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, simulationJob := range resp.SimulationJobSummaries {
+			if simulationJobNeedsToBeCanceled(simulationJob) {
+				resources = append(resources, &RoboMakerSimulationJob{
+					svc: svc,
+					arn: simulationJob.Arn,
+				})
+			}
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RoboMakerSimulationJob) Remove() error {
+
+	_, err := f.svc.CancelSimulationJob(&robomaker.CancelSimulationJobInput{
+		Job: f.arn,
+	})
+
+	return err
+}
+
+func (f *RoboMakerSimulationJob) String() string {
+	return *f.arn
+}


### PR DESCRIPTION
Provides support for removing:

- robots
- fleets
- robot applications
- simulation applications

and canceling:
- deployment jobs
- simulation jobs

there is no delete operations on the latter two.